### PR TITLE
Repeat pseudo-selectors in a way that keeps them valid

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,6 @@ module.exports = function classRepeat (selector, options) {
       if (node.type === 'class' || isPseudo(node)) {
         for (var i = 0; i < options.repeat; i++) {
           tokensWithRepeatedClasses.push(node)
-
-          var nextToken = tokens.nodes[index + 1]
         }
       } else {
         tokensWithRepeatedClasses.push(node)

--- a/index.js
+++ b/index.js
@@ -16,14 +16,11 @@ module.exports = function classRepeat (selector, options) {
     var tokens = SelectorTokenizer.parse(selector).nodes[0] || { nodes: [] }
     var tokensWithRepeatedClasses = []
     tokens.nodes.map(function (node, index) {
-      if (node.type === 'class') {
+      if (node.type === 'class' || isPseudo(node)) {
         for (var i = 0; i < options.repeat; i++) {
           tokensWithRepeatedClasses.push(node)
 
           var nextToken = tokens.nodes[index + 1]
-          if (isPresent(nextToken) && isPseudo(nextToken) && i + 1 !== options.repeat) {
-            tokensWithRepeatedClasses.push(nextToken)
-          }
         }
       } else {
         tokensWithRepeatedClasses.push(node)

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function classRepeat (selector, options) {
     var tokens = SelectorTokenizer.parse(selector).nodes[0] || { nodes: [] }
     var tokensWithRepeatedClasses = []
     tokens.nodes.map(function (node, index) {
-      if (node.type === 'class' || isPseudo(node)) {
+      if (node.type === 'class') {
         for (var i = 0; i < options.repeat; i++) {
           tokensWithRepeatedClasses.push(node)
         }
@@ -35,8 +35,4 @@ module.exports = function classRepeat (selector, options) {
   } else {
     return selector
   }
-}
-
-function isPseudo(token) {
-  return token && (token.type === 'pseudo-element' || token.type === 'pseudo-class')
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "is-present": "^1.0.0"
   },
   "devDependencies": {
-    "ava": "*"
+    "ava": "^0.23.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -2,10 +2,11 @@ import test from 'ava'
 import classRepeat from './'
 
 test('class-repeat repeats classes', t => {
-  t.plan(5)
+  t.plan(6)
 
   t.deepEqual(classRepeat('.foo.bar'), '.foo.foo.bar.bar')
-  t.deepEqual(classRepeat('.foo:before'), '.foo:before.foo:before')
+  t.deepEqual(classRepeat('.foo:hover'), '.foo.foo:hover:hover')
+  t.deepEqual(classRepeat('.foo::before'), '.foo.foo::before::before')
   t.deepEqual(classRepeat('.foo .bar.baz'), '.foo.foo .bar.bar.baz.baz')
   t.deepEqual(classRepeat('input.foo-bar.baz > .pizazz'), 'input.foo-bar.foo-bar.baz.baz > .pizazz.pizazz')
   t.deepEqual(classRepeat('.foo', { repeat: 4 }), '.foo.foo.foo.foo')

--- a/test.js
+++ b/test.js
@@ -4,9 +4,9 @@ import classRepeat from './'
 test('class-repeat repeats classes', t => {
   t.plan(5)
 
-  t.same(classRepeat('.foo.bar'), '.foo.foo.bar.bar')
-  t.same(classRepeat('.foo:before'), '.foo:before.foo:before')
-  t.same(classRepeat('.foo .bar.baz'), '.foo.foo .bar.bar.baz.baz')
-  t.same(classRepeat('input.foo-bar.baz > .pizazz'), 'input.foo-bar.foo-bar.baz.baz > .pizazz.pizazz')
-  t.same(classRepeat('.foo', { repeat: 4 }), '.foo.foo.foo.foo')
+  t.deepEqual(classRepeat('.foo.bar'), '.foo.foo.bar.bar')
+  t.deepEqual(classRepeat('.foo:before'), '.foo:before.foo:before')
+  t.deepEqual(classRepeat('.foo .bar.baz'), '.foo.foo .bar.bar.baz.baz')
+  t.deepEqual(classRepeat('input.foo-bar.baz > .pizazz'), 'input.foo-bar.foo-bar.baz.baz > .pizazz.pizazz')
+  t.deepEqual(classRepeat('.foo', { repeat: 4 }), '.foo.foo.foo.foo')
 })

--- a/test.js
+++ b/test.js
@@ -5,8 +5,8 @@ test('class-repeat repeats classes', t => {
   t.plan(6)
 
   t.deepEqual(classRepeat('.foo.bar'), '.foo.foo.bar.bar')
-  t.deepEqual(classRepeat('.foo:hover'), '.foo.foo:hover:hover')
-  t.deepEqual(classRepeat('.foo::before'), '.foo.foo::before::before')
+  t.deepEqual(classRepeat('.foo:hover'), '.foo.foo:hover')
+  t.deepEqual(classRepeat('.foo::before'), '.foo.foo::before')
   t.deepEqual(classRepeat('.foo .bar.baz'), '.foo.foo .bar.bar.baz.baz')
   t.deepEqual(classRepeat('input.foo-bar.baz > .pizazz'), 'input.foo-bar.foo-bar.baz.baz > .pizazz.pizazz')
   t.deepEqual(classRepeat('.foo', { repeat: 4 }), '.foo.foo.foo.foo')


### PR DESCRIPTION
Some browsers (Chrome, at least), does not consider `.foo:before.foo:before` a valid selector. However `.foo.foo:before:before` seems to work fine and still doubles up everything the same as before.

I'm not sure if @johnotander intends "class repeat" to mean "(pseudo-)class repeat" or just literal classes, so a different version of this could be prepared which results in `.foo.foo:before`, if preferred.

Designed to fix johnotander/postcss-class-repeat#1, which I probably should have opened on this repo.